### PR TITLE
Corrected SwaggerUI URL

### DIFF
--- a/api-doc/README.md
+++ b/api-doc/README.md
@@ -78,7 +78,7 @@ Consequently, the API endpoints and options in the UI will be enabled/disabled. 
 
 ### Generation, revocation and value set API doc
   - [API File](api-docs.yaml)
-  - [SwaggerUI](https://editor.swagger.io/?url=https://raw.githubusercontent.com/admin-ch/CovidCertificate-Apidoc/main/api-docs.yaml)
+  - [SwaggerUI](https://editor.swagger.io/?url=https://raw.githubusercontent.com/admin-ch/CovidCertificate-Documents/main/api-doc/api-docs.yaml)
 
 ### Verification API doc
 We do not recommend the use of the API. To save the effort of implementing the API, a Docker image of a verification service is provided. This one contains an endpoint that allows you to check, through its QR-Code, the validity of a certificate.


### PR DESCRIPTION
SwaggerUI's URL was broken since the API docs were moved between repositories:
![image](https://user-images.githubusercontent.com/11660256/190440457-b80a288f-b3d6-41de-9ee5-c46b79d468e6.png)
